### PR TITLE
Workaround for JS error: "TypeError: h$concur is undefined"

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "author": "Anupam Jain",
   "license": "ISC",
   "dependencies": {
+    "react": "^16.1.0",
+    "react-dom": "^16.1.0",
     "react-sortable-tree": "^1.2.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,10 +6,5 @@ module.exports = {
         // export itself to a global var: "h$concur"
         libraryTarget: "var",
         library: "h$concur"
-    },
-    externals: {
-        // Load React deps from the concur-react library
-        "react": "h$concur.react",
-        "react-dom": "h$concur.reactDom"
     }
 };


### PR DESCRIPTION
These changes are inspired by package.json and webpack.config.js from https://github.com/concurhaskell/concur-react-starter ( eefa5d5 ) and their goal is to avoid a run-time JS error (TypeError: h$concur is undefined) that prevents the SortableTree component from displaying at all.

I am a webpack newbie so I might be very wrong but in my understanding these changes seem to contradict the advice given here:

https://github.com/concurhaskell/concur-react-starter#important-note-you-dont-need-to-add-react-and-reactdom-in-packagejson-as-those-dependencies-will-be-pulled-from-concur-react

"IMPORTANT NOTE: You don't need to add React and ReactDOM in package.json, as those dependencies will be pulled from Concur-React."

With these changes, the JS error doesn't happen and the SortableTree is displayed and works as expected.